### PR TITLE
v2.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## CHANGE LOG
 BonusBits Orchestrator
 
+## 2.3.6 - 09/22/2021 - Levon Becker
+* Added missing parent_id arg for org_account module
+* Fixed pathing for org_accounts and org_policies roles examples module path rename missed.
+* Added dynamic custom tagging to org_accounts role example. So each aws account can have custom tags.
+* The root account id can be used if no OUs are setup
+
 ## 2.3.5 - 09/22/2021 - Levon Becker
 * Fixed tag issue in org_account module
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Project Release](https://img.shields.io/badge/release-v2.3.5-blue.svg)](https://github.com/bonusbits/bonusbits_orchestrator)
+[![Project Release](https://img.shields.io/badge/release-v2.3.6-blue.svg)](https://github.com/bonusbits/bonusbits_orchestrator)
 [![Circle CI](https://circleci.com/gh/bonusbits/bonusbits_orchestrator/tree/master.svg?style=shield)](https://circleci.com/gh/bonusbits/bonusbits_orchestrator/tree/master)
 [![GitHub issues](https://img.shields.io/github/issues/bonusbits/bonusbits_orchestrator.svg)](https://github.com/bonusbits/bonusbits_orchestrator/issues)
 

--- a/terraform/environments/examples/org_accounts/main.tf
+++ b/terraform/environments/examples/org_accounts/main.tf
@@ -1,4 +1,5 @@
 module "aws_tags" {
+  for_each                      = var.org_accounts
   cli_vars                      = {
     orchestrator_version        = var.orchestrator_version
     terraform_environment       = var.terraform_environment
@@ -6,7 +7,10 @@ module "aws_tags" {
   }
   source                        = "../../../modules/aws_tags"
   terraform_role                = "aws_org_accounts"
-  tfv_custom_aws_tags           = var.custom_aws_tags
+  tfv_custom_aws_tags           = {
+    Environment                 = each.value.environment
+    Owner                       = each.value.email
+  }
 }
 
 # Bastion
@@ -15,7 +19,8 @@ module "org_accounts" {
   base_aws_tags                 = module.aws_tags.aws_tags
   name                          = each.value.name
   email                         = each.value.email
-  source                        = "../../../modules/aws_org_account"
+  parent_id                     = each.value.parent_id
+  source                        = "../../../modules/org_account"
   iam_user_access_to_billing    = each.value.iam_user_access_to_billing
   role_name                     = each.value.role_name
   service_control_policy_id     = each.value.service_control_policy_id

--- a/terraform/environments/examples/org_policies/main.tf
+++ b/terraform/environments/examples/org_policies/main.tf
@@ -17,5 +17,5 @@ module "org_policies" {
   name                          = each.value.name
   type                          = each.value.type
   content                       = local.policies[each.key]
-  source                        = "../../../modules/aws_org_policy"
+  source                        = "../../../modules/org_policy"
 }

--- a/terraform/modules/org_account/main.tf
+++ b/terraform/modules/org_account/main.tf
@@ -1,6 +1,7 @@
 resource "aws_organizations_account" "default" {
   name                          = var.name
   email                         = var.email
+  parent_id                     = var.parent_id
   iam_user_access_to_billing    = var.iam_user_access_to_billing
   role_name                     = var.role_name
   tags                          = local.aws_tags

--- a/terraform/modules/org_account/variables.tf
+++ b/terraform/modules/org_account/variables.tf
@@ -1,6 +1,7 @@
 variable base_aws_tags {}
 variable name {type = string}
 variable email {type = string}
+variable parent_id {type = string}
 variable iam_user_access_to_billing {}
 variable role_name {type = string}
 //variable service_control_policy_id {type = string}

--- a/vars/terraform/examples/org_accounts.tfvars
+++ b/vars/terraform/examples/org_accounts.tfvars
@@ -1,6 +1,7 @@
 org_accounts = {
   jane_lab = {
     email                       = "jane.doe@mydomain.com"
+    environment                 = "lab"
     name                        = "janes_lab"
     parent_id                   = "ou-xxxx-xxxxxxxx"
     iam_user_access_to_billing  = "DENY"
@@ -9,6 +10,7 @@ org_accounts = {
   }
   johns_lab = {
     email                       = "john.doe@mydomain.com"
+    environment                 = "lab"
     name                        = "johns_lab"
     parent_id                   = "ou-xxxx-xxxxxxxx"
     iam_user_access_to_billing  = "DENY"

--- a/version.yml
+++ b/version.yml
@@ -1,1 +1,1 @@
-orchestrator: 2.3.5
+orchestrator: 2.3.6


### PR DESCRIPTION
## Change Details
* Added missing parent_id arg for org_account module
* Fixed pathing for org_accounts and org_policies roles examples module path rename missed.
* Added dynamic custom tagging to org_accounts role example. So each aws account can have custom tags.
* The root account id can be used if no OUs are setup
